### PR TITLE
Use a higher box_threshold for trees when the GroundingDINO box is too large.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,24 @@ The method used here has some important modifications from the vanilla segment-g
 ```
 make_mask.py /path/to/tiff/images \
 --output /path/to/output/directory \
---tile-size=600 \                    # Size of tiles to split image into in pixels
+--tile-size=600 \                    
 --tile-overlap=30 \                  # Percentage overlap of tiles
 --box-reject=0.9 \                   # Fraction of tile area to reject GroundingDINO boxes
 --high-box-threshold=0.35 \          # Box threshold for rejecting GroundingDINO boxes larger tha box-reject
 --box-threshold=0.23                 # Base box threshold for GroundingDINO
 ```
+
+In the above example the options are:
+
+`--tile-size=600`: The size in pixels of tiles to split the input images into.
+
+`--tile-overlap=30`: Overlap size (as a percentage of `tile-size`) and padding of the tiles. With the options `--tile-size=600` and `--tile-overlap=30` roughly 30 tiles of size 1400x1400 are created for an input image of 3000x3000 pixels.
+
+`--box-reject=0.9`: Reject GroundingDINO boxes larger than 90% of the tile size with value below `--high-box-threshold`.
+
+`--high-box-threshold=0.35`: Box threshold for rejecting GroundingDINO boxes larger than box-reject.
+
+`--box-threshold=0.23`: Box threshold for boxes smaller the `box-reject=0.9`.
 
 ## Dataset
 

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ The method used here has some important modifications from the vanilla segment-g
 ```
 make_mask.py /path/to/tiff/images \
 --output /path/to/output/directory \
---tile-size=600 \                    
---tile-overlap=30 \                  # Percentage overlap of tiles
---box-reject=0.9 \                   # Fraction of tile area to reject GroundingDINO boxes
---high-box-threshold=0.35 \          # Box threshold for rejecting GroundingDINO boxes larger tha box-reject
---box-threshold=0.23                 # Base box threshold for GroundingDINO
+--tile-size=600 \
+--tile-overlap=30 \
+--box-reject=0.9 \
+--high-box-threshold=0.35 \
+--box-threshold=0.23
 ```
 
 In the above example the options are:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Images and annotations stored in COCO JSON format.
 
 
 
-## Instructions
+## Installation Instructions
 
 ```
 conda create --name aerial-annotation python=3.9
@@ -21,6 +21,33 @@ conda activate aerial-annotation
 
 pip install -r requirements.txt
 
+```
+
+## Annotating Trees
+
+The script `make_mask.py` in the `scripts` directory can be used to create tree annotations for a set of `.tiff` format aerial images. It uses a modified form of the
+`LangSAM` model that is part of the [segment-geospatial](https://samgeo.gishub.org/) package. This leverages both GroundingDINO and the Segment Anything Model with a
+text prompt `tree` to detect trees in aerial imagery: see [here](https://samgeo.gishub.org/examples/text_prompts/) for an example of using segment-geospatial to detect
+trees.
+
+The method used here has some important modifications from the vanilla segment-geospatial package:
+
+- It adds a new box size threshold called `box-reject` that rejects GroundingDINO boxes that are larger than a given fraction of the input image.
+
+- For boxes larger than `box-reject` a secondary `box-threshold` is used to allow for large boxes containg trees at high confidence.
+
+- Tree annotation masks from overlapping tiles are merged without a call to `gdal.warp`. Instead they are merged by accepting only pixels in the merged mask that are annotated in more than 50% of the individual tiles.
+
+#### Example usage:
+
+```
+make_mask.py /path/to/tiff/images \
+--output /path/to/output/directory \
+--tile-size=600 \                    # Size of tiles to split image into in pixels
+--tile-overlap=30 \                  # Percentage overlap of tiles
+--box-reject=0.9 \                   # Fraction of tile area to reject GroundingDINO boxes
+--high-box-threshold=0.35 \          # Box threshold for rejecting GroundingDINO boxes larger tha box-reject
+--box-threshold=0.23                 # Base box threshold for GroundingDINO
 ```
 
 ## Dataset

--- a/scripts/make_mask.py
+++ b/scripts/make_mask.py
@@ -387,6 +387,9 @@ def merge_mask(tile_files, template, output, mask_fraction=0.5):
        is then derived by only accepting pixels in the ratio that are greater than
        `mask_fraction`.
 
+    The `mask_fraction` default of 50% was chosen empirically via experiments merging masks with
+    a range of numbers of overlapping tiles.
+
     Parameters:
     tile_files: (list of str) A list of the paths to the input TIFF image mask files
     template: (str) A template TIFF image to paste the individual masks onto

--- a/scripts/make_mask.py
+++ b/scripts/make_mask.py
@@ -342,13 +342,16 @@ def run_model(
     gc.collect()
 
 
-def annotate_trees_batch(input_images, output_dir, delete_mask_raster=False, **kwargs):
+def annotate_trees_batch(
+    input_images, output_dir, delete_mask_raster=False, restart=True, **kwargs
+):
     """Run annotate_trees on a list of input GeoTIFF images.
 
     Parameters:
     input_images: (list) List of input GeoTIFF image filenames.
     output_dir: (str) Directory to place output files.
     delete_mask_raster: (bool) Remove the merged raster mask (in favour of the vector GeoJSON)
+    restart: (bool) Dont do annotations on files where its already been done
     **kwargs: (dict) Keyword arguments passed to annotate_trees.
     """
 
@@ -356,6 +359,10 @@ def annotate_trees_batch(input_images, output_dir, delete_mask_raster=False, **k
         print(f"Annotating {image}")
         image_filename = os.path.basename(image)
         output_basename = os.path.splitext(image_filename)[0]
+        if restart and os.path.exists(
+            os.path.join(output_dir, output_basename) + ".geojson"
+        ):
+            continue
         annotate_trees(
             image, output_root=os.path.join(output_dir, output_basename), **kwargs
         )

--- a/scripts/make_mask.py
+++ b/scripts/make_mask.py
@@ -74,7 +74,9 @@ def predict_with_box_reject(
 ):
     """Run both GroundingDINO and SAM model prediction on a single image.
 
-    NOTE: Stolen from LangSAM.predict() but this adds an option to reject boxes larger than
+    NOTE: This makes use of code from from LangSAM.predict() 
+    (under MIT License at https://github.com/opengeos/segment-geospatial/blob/main/LICENSE)
+    but this adds an option to reject boxes larger than
     a given fraction of the image area before the SAM predict step. This is inteded to be
     monkey-patched into the LangSAM model via the following signature:
 
@@ -215,7 +217,8 @@ def show_anns_text(
     """Show the annotations (objects with random color) on the input image.
 
     This function is taken from the LangSAM model in the segment-geospatial library
-    https://github.com/opengeos/segment-geospatial/blob/main/samgeo/text_sam.py#L423
+    (under MIT License at https://github.com/opengeos/segment-geospatial/blob/main/LICENSE)
+    at https://github.com/opengeos/segment-geospatial/blob/main/samgeo/text_sam.py#L423
     with the added feature of printing the box logits in the bottom left of the boxes.
     It can be monkey-patched into the LangSAM class using a similar method to that
     described in the docstring for the `predict_with_box_reject` function in this module.
@@ -323,7 +326,7 @@ def run_model(
     output_dir: (str) Output directory for the prediction mask files.
     text_prompt: (str) Text prompt for the model.
     box_reject: (float) Fraction of image area to reject box predictions.
-    high_box_threshold: (float) Box threshold for boxes larger than box-reject.
+    high_box_threshold: (float) Box threshold for boxes larger than box_reject.
     """
 
     LangSAM.predict = partialmethod(

--- a/scripts/make_mask.py
+++ b/scripts/make_mask.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import argparse
+import gc
 import glob
 import os
 import shutil
@@ -333,6 +334,8 @@ def run_model(
         merge=True,
         verbose=True,
     )
+    del sam
+    gc.collect()
 
 
 def annotate_trees_batch(input_images, output_dir, delete_mask_raster=False, **kwargs):
@@ -404,8 +407,8 @@ def annotate_trees(
     # Ensure the input is reprojected to desired projection
     # This is because the model failes on some projections.
     if reproject is not None:
-        in_name, in_ext = os.path.splitext(input_image)
-        rep_image = in_name + "_rep" + in_ext
+        _, in_ext = os.path.splitext(input_image)
+        rep_image = output_root + "_rep" + in_ext
         in_im = rioxarray.open_rasterio(input_image)
         rep_im = in_im.rio.reproject(reproject)
         rep_im.rio.to_raster(rep_image, compress="DEFLATE", tiled=True)


### PR DESCRIPTION
This PR contains a few enhancements:

1. It addresses the issues missing large swathes of trees in tiles described in #10 & #25.
2. It removes GDAL dependency for the script (Issue #26).
3. It improves handling of overlapping tiles when combining peprojecting tile masks to the input (https://github.com/Sydney-Informatics-Hub/aerial-annotation/issues/26#issuecomment-1827139336).
4. Allow restarting based upon existing output files when in batch mode.

It closes #10 and closes #25 and closes #26 