### PR TITLE
Download raster files in JPEG format from sixmaps Web Map Server

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ opencv-python
 osmtogeojson
 overpass
 overpy
+owslib
 Pillow
 pre-commit
 rasterio

--- a/scripts/get_raster_jpeg.py
+++ b/scripts/get_raster_jpeg.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+import os
+import time
+
+import geojson
+from owslib.wms import WebMapService
+
+# Download a list of JPEG tiles from the NSW Six Maps Web Map Server.
+# Tile boundaries are define in the input GeoJSON file
+
+SIXMAPS_WMS_URL = (
+    "http://maps.six.nsw.gov.au/arcgis/services/public/NSW_Imagery/MapServer/WmsServer"
+)
+SIXMAPS_WMS_VERSION = "1.3.0"
+OUTPUT_DIR = "output_tiles"
+INPUT_JSON = "GSU_grid.geojson"
+# Pixel scale is 0.0746455m at Zoom=21
+# GSU_grid.geojson is 300x300m
+SIZE = (4019, 4019)
+
+with open(INPUT_JSON) as file:
+    raw_geojson = geojson.load(file)
+
+geojson_feature_list = raw_geojson["features"]
+num_tiles = len(geojson_feature_list)
+print(f"{len(geojson_feature_list)} tiles to download.")
+
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+wms = WebMapService(SIXMAPS_WMS_URL, version=SIXMAPS_WMS_VERSION)
+
+for i, feature in enumerate(geojson_feature_list):
+    this_id = feature["properties"]["id"]
+    this_bbox = (
+        feature["properties"][edge] for edge in ["left", "bottom", "right", "top"]
+    )
+    output_file = os.path.join(OUTPUT_DIR, str(this_id) + ".jpg")
+    # Don't downliad tiles already downloaded.
+    if os.path.exists(output_file):
+        print(f"Skipping Tile {i + 1}. File {output_file} exists.")
+        continue
+    print(f"Get tile {i + 1} of {num_tiles} -> {output_file}")
+    # st = time.time()
+    image_request = wms.getmap(
+        bbox=this_bbox, srs="EPSG:3857", layers=["0"], size=SIZE, format="image/jpeg"
+    )
+    with open(output_file, "wb") as this_image:
+        this_image.write(image_request.read())
+    # et = time.time()
+    # Benchmark
+    # print(et - st)

--- a/scripts/get_raster_jpeg.py
+++ b/scripts/get_raster_jpeg.py
@@ -3,6 +3,7 @@ import os
 import time
 
 import geojson
+import requests
 from owslib.wms import WebMapService
 
 # Download a list of JPEG tiles from the NSW Six Maps Web Map Server.
@@ -18,6 +19,26 @@ INPUT_JSON = "GSU_grid.geojson"
 # GSU_grid.geojson is 300x300m
 SIZE = (4019, 4019)
 
+
+def request_image_from_server(wms_instance, output_file, attempts=3, **kwargs):
+    """Try to download image using defined WMS instance with multiple attempts.
+
+    Raise a `ReadTimeout` if the exception is reaised more than
+    `attempts` times. kwargs are passed to wms_instance.getmap
+    """
+    this_attempt = 1
+    while this_attempt <= attempts:
+        try:
+            image_request = wms_instance.getmap(**kwargs)
+            with open(output_file, "wb") as this_image:
+                this_image.write(image_request.read())
+            break
+        except requests.exceptions.ReadTimeout:
+            this_attempt += 1
+            if this_attempt > attempts:
+                raise
+
+
 with open(INPUT_JSON) as file:
     raw_geojson = geojson.load(file)
 
@@ -27,7 +48,7 @@ print(f"{len(geojson_feature_list)} tiles to download.")
 
 os.makedirs(OUTPUT_DIR, exist_ok=True)
 
-wms = WebMapService(SIXMAPS_WMS_URL, version=SIXMAPS_WMS_VERSION)
+wms = WebMapService(SIXMAPS_WMS_URL, version=SIXMAPS_WMS_VERSION, timeout=60)
 
 for i, feature in enumerate(geojson_feature_list):
     this_id = feature["properties"]["id"]
@@ -40,12 +61,17 @@ for i, feature in enumerate(geojson_feature_list):
         print(f"Skipping Tile {i + 1}. File {output_file} exists.")
         continue
     print(f"Get tile {i + 1} of {num_tiles} -> {output_file}")
-    # st = time.time()
-    image_request = wms.getmap(
-        bbox=this_bbox, srs="EPSG:3857", layers=["0"], size=SIZE, format="image/jpeg"
+    st = time.time()
+    request_image_from_server(
+        wms,
+        output_file,
+        attempts=3,
+        bbox=this_bbox,
+        srs="EPSG:3857",
+        layers=["0"],
+        size=SIZE,
+        format="image/jpeg",
     )
-    with open(output_file, "wb") as this_image:
-        this_image.write(image_request.read())
-    # et = time.time()
+    et = time.time()
     # Benchmark
-    # print(et - st)
+    print(et - st)

--- a/scripts/get_raster_jpeg.py
+++ b/scripts/get_raster_jpeg.py
@@ -3,21 +3,13 @@ import os
 import time
 
 import geojson
+import numpy as np
 import requests
+from dask import compute, delayed
 from owslib.wms import WebMapService
 
 # Download a list of JPEG tiles from the NSW Six Maps Web Map Server.
 # Tile boundaries are define in the input GeoJSON file
-
-SIXMAPS_WMS_URL = (
-    "http://maps.six.nsw.gov.au/arcgis/services/public/NSW_Imagery/MapServer/WmsServer"
-)
-SIXMAPS_WMS_VERSION = "1.3.0"
-OUTPUT_DIR = "output_tiles"
-INPUT_JSON = "GSU_grid.geojson"
-# Pixel scale is 0.0746455m at Zoom=21
-# GSU_grid.geojson is 300x300m
-SIZE = (4019, 4019)
 
 
 def request_image_from_server(wms_instance, output_file, attempts=3, **kwargs):
@@ -39,39 +31,82 @@ def request_image_from_server(wms_instance, output_file, attempts=3, **kwargs):
                 raise
 
 
-with open(INPUT_JSON) as file:
-    raw_geojson = geojson.load(file)
+def download_tiles(features, output_dir):
+    """Download tiles defined in `features` to `output_dir`"""
 
-geojson_feature_list = raw_geojson["features"]
-num_tiles = len(geojson_feature_list)
-print(f"{len(geojson_feature_list)} tiles to download.")
+    SIXMAPS_WMS_URL = "http://maps.six.nsw.gov.au/arcgis/services/public/NSW_Imagery/MapServer/WmsServer"
+    SIXMAPS_WMS_VERSION = "1.3.0"
+    # Pixel scale is 0.0746455m at Zoom=21
+    # GSU_grid.geojson is 300x300m
+    SIZE = (4019, 4019)
 
-os.makedirs(OUTPUT_DIR, exist_ok=True)
+    wms = WebMapService(SIXMAPS_WMS_URL, version=SIXMAPS_WMS_VERSION, timeout=60)
 
-wms = WebMapService(SIXMAPS_WMS_URL, version=SIXMAPS_WMS_VERSION, timeout=60)
+    for feature in features:
+        this_id = feature["properties"]["id"]
+        this_bbox = (
+            feature["properties"][edge] for edge in ["left", "bottom", "right", "top"]
+        )
+        output_file = os.path.join(output_dir, str(this_id) + ".jpg")
+        # Don't downliad tiles already downloaded.
+        if os.path.exists(output_file):
+            print(f"File {output_file} exists. Skipping it....")
+            continue
+        print(f"Download tile to {output_file}")
+        st = time.time()
+        request_image_from_server(
+            wms,
+            output_file,
+            attempts=3,
+            bbox=this_bbox,
+            srs="EPSG:3857",
+            layers=["0"],
+            size=SIZE,
+            format="image/jpeg",
+        )
+        et = time.time()
+        # Benchmark
+        print(et - st)
 
-for i, feature in enumerate(geojson_feature_list):
-    this_id = feature["properties"]["id"]
-    this_bbox = (
-        feature["properties"][edge] for edge in ["left", "bottom", "right", "top"]
+
+def get_chunk_slices(list_length, num_chunks):
+    """Return a list of `num_chunks` slices which roughly split `list_length`
+    equally."""
+    chunk_indices = np.array_split(np.arange(list_length), num_chunks)
+    avg_size = int(np.average([len(chunk) for chunk in chunk_indices]))
+    print(
+        f"Split {list_length} objects into {num_chunks} x {avg_size} parallel chunks."
     )
-    output_file = os.path.join(OUTPUT_DIR, str(this_id) + ".jpg")
-    # Don't downliad tiles already downloaded.
-    if os.path.exists(output_file):
-        print(f"Skipping Tile {i + 1}. File {output_file} exists.")
-        continue
-    print(f"Get tile {i + 1} of {num_tiles} -> {output_file}")
-    st = time.time()
-    request_image_from_server(
-        wms,
-        output_file,
-        attempts=3,
-        bbox=this_bbox,
-        srs="EPSG:3857",
-        layers=["0"],
-        size=SIZE,
-        format="image/jpeg",
-    )
-    et = time.time()
-    # Benchmark
-    print(et - st)
+    return [
+        slice(a[0], a[-1] + 1)
+        for a in np.array_split(np.arange(list_length), num_chunks)
+    ]
+
+
+def main():
+    INPUT_JSON = "GSU_grid.geojson"
+    OUTPUT_DIR = "output_tiles"
+    N_THREADS = 5
+
+    with open(INPUT_JSON) as file:
+        raw_geojson = geojson.load(file)
+
+    geojson_feature_list = raw_geojson["features"]
+    num_tiles = len(geojson_feature_list)
+    print(f"{num_tiles} tiles to process....")
+
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+    # Split up geojson_feature_list into N_THREADS roughly equal chunks
+    chunk_slices = get_chunk_slices(num_tiles, N_THREADS)
+    # Create N_THREADS function calls - one for each chunk slice in the tile list.
+    chunked_download = [
+        delayed(download_tiles)(geojson_feature_list[part], OUTPUT_DIR)
+        for part in chunk_slices
+    ]
+    # Go get em.
+    compute(*chunked_download)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
A draft script to download tiles using the sixmaps Web Map Server. It requires `owslib` to run.

Currently everything is hard-coded at the top of the script and you can uncomment the statement at the end to check the download speed.

I've put the hardcoded `GSU_grid.geojson` imput file with the ~37000 300x3000m tile edges on [sharepoint](https://unisyd.sharepoint.com/teams/SydneyInformaticsHub2/Shared%20Documents/Forms/AllItems.aspx?csf=1&web=1&e=xDhZqb&cid=aa0bed13%2D77a8%2D4c29%2Dad6d%2Ddb6d4b58d1b7&FolderCTID=0x01200036946701AA9B66498938268891B63695&id=%2Fteams%2FSydneyInformaticsHub2%2FShared%20Documents%2F1%20SIH%20Central%20Document%20Repository%2FProjects%2F1%20JIRA%20projects%2FPIPE%2D3956%20Urban%20Heat%20Islands%2Fdata%2Fgreater%5Fsydney%5FGSU%5Fgrid%5F300x300&viewid=0a2a83b7%2D13a7%2D412d%2D9f50%2Df9174718726a).